### PR TITLE
fix: solves error in chatgpt review action

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -14,5 +14,5 @@ jobs:
     steps:
       - uses: anc95/ChatGPT-CodeReview@main
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.MY_GITHUB_TOKEN }}"
           OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"


### PR DESCRIPTION
- Ajusta a chave por que o github não deixa cadastrar uma chave com préfixo `GITHUB`